### PR TITLE
Allow Symfony 5 + fix using the Process class

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,7 +15,7 @@ return PhpCsFixer\Config::create()
         '@PHPUnit60Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        'array_syntax' => array('syntax' => 'long'),
+        'array_syntax' => array('syntax' => 'short'),
         'combine_consecutive_unsets' => true,
         // one should use PHPUnit methods to set up expected exception instead of annotations
         'general_phpdoc_annotation_remove' => array('annotations' => array('expectedException', 'expectedExceptionMessage', 'expectedExceptionMessageRegExp')),

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": "^5.3.6 || ^7.0",
-        "symfony/process": "^2.3 || ^3 || ^4"
+        "php": "^5.5.9 || ^7.0",
+        "symfony/process": "^3.4 || ^4 || ^5"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.9",
         "maglnet/composer-require-checker": "^0.1.6",
         "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1",
-        "symfony/phpunit-bridge": "^4.0"
+        "symfony/phpunit-bridge": "^4.0 || ^5.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/src/BashScriptExecutor.php
+++ b/src/BashScriptExecutor.php
@@ -28,7 +28,7 @@ final class BashScriptExecutor
     public function __construct($scriptParts, $cwd)
     {
         @trigger_error('`\Keradus\CliExecutor\BashScriptExecutor` is deprecated, use `\Keradus\CliExecutor\ScriptExecutor` instead.', E_USER_DEPRECATED);
-        $this->scriptExecutor = new ScriptExecutor($scriptParts, $cwd, array('#!/usr/bin/env bash', 'set -e', ''));
+        $this->scriptExecutor = new ScriptExecutor($scriptParts, $cwd, ['#!/usr/bin/env bash', 'set -e', '']);
     }
 
     /**

--- a/src/CommandExecutor.php
+++ b/src/CommandExecutor.php
@@ -16,7 +16,7 @@ use Symfony\Component\Process\Process;
 final class CommandExecutor
 {
     /**
-     * @var string
+     * @var string|array
      */
     private $command;
 
@@ -31,8 +31,8 @@ final class CommandExecutor
     private $result;
 
     /**
-     * @param string $command
-     * @param string $cwd
+     * @param string|array $command
+     * @param string       $cwd
      */
     public function __construct($command, $cwd)
     {
@@ -41,8 +41,8 @@ final class CommandExecutor
     }
 
     /**
-     * @param string $command
-     * @param string $cwd
+     * @param string|array $command
+     * @param string       $cwd
      *
      * @return self
      */
@@ -61,8 +61,7 @@ final class CommandExecutor
     public function getResult($checkCode = true)
     {
         if (null === $this->result) {
-            // for symfony/process:^4.2
-            if (method_exists(Process::class, 'fromShellCommandline')) {
+            if (\is_string($this->command) && method_exists(Process::class, 'fromShellCommandline')) {
                 $process = Process::fromShellCommandline($this->command, $this->cwd);
             } else {
                 $process = new Process($this->command, $this->cwd);
@@ -81,7 +80,7 @@ final class CommandExecutor
                 $this->result,
                 sprintf(
                     "Cannot execute `%s`:\nCode: %s\nExit text: %s\nError output: %s\nDetails:\n%s",
-                    $this->command,
+                    $process->getCommandLine(),
                     $this->result->getCode(),
                     isset(Process::$exitCodes[$this->result->getCode()]) ? Process::$exitCodes[$this->result->getCode()] : 'Unknown exit code',
                     $this->result->getError(),

--- a/src/ScriptExecutor.php
+++ b/src/ScriptExecutor.php
@@ -54,7 +54,7 @@ final class ScriptExecutor
     {
         $this->scriptParts = $scriptParts;
         $this->cwd = $cwd;
-        $this->scriptInit = null !== $scriptInit ? $scriptInit : array('#!/bin/sh', 'set -eu', '');
+        $this->scriptInit = null !== $scriptInit ? $scriptInit : ['#!/bin/sh', 'set -eu', ''];
     }
 
     public function __destruct()
@@ -93,12 +93,7 @@ final class ScriptExecutor
             chmod($this->tmpFilePath, 0777);
             $command = './'.$tmpFileName;
 
-            // for symfony/process:^4.2
-            if (method_exists(Process::class, 'fromShellCommandline')) {
-                $process = Process::fromShellCommandline($command, $this->cwd);
-            } else {
-                $process = new Process($command, $this->cwd);
-            }
+            $process = new Process([$command], $this->cwd);
             $process->run();
 
             $this->result = new CliResult(

--- a/tests/CommandExecutorTest.php
+++ b/tests/CommandExecutorTest.php
@@ -29,4 +29,13 @@ class CommandExecutorTest extends TestCase
 
         $this->assertContains(basename(__FILE__), $cliResult->getOutput());
     }
+
+    public function testSimpleExecutionWithArray()
+    {
+        $scriptExecutor = CommandExecutor::create(['ls', '-l'], __DIR__);
+
+        $cliResult = $scriptExecutor->getResult();
+
+        $this->assertContains(basename(__FILE__), $cliResult->getOutput());
+    }
 }

--- a/tests/ScriptExecutorTest.php
+++ b/tests/ScriptExecutorTest.php
@@ -23,7 +23,7 @@ class ScriptExecutorTest extends TestCase
 {
     public function testSimpleExecution()
     {
-        $scriptExecutor = ScriptExecutor::create(array('ls'), __DIR__);
+        $scriptExecutor = ScriptExecutor::create(['ls'], __DIR__);
 
         $cliResult = $scriptExecutor->getResult();
 


### PR DESCRIPTION
This PR is on the critical path to making php-cs-fixer compatible with Symfony 5.

It fixes the following:
- PHP 5.3 was not supported already, because `Process::class` is not supported syntax there
- this means we can use Symfony 3.4 minimum, the lowest maintained Symfony version
- using `Process::fromShellCommandline()` with arbitrary strings is as bad as using concatenation for building SQL queries.
