### PR TITLE
Add support for Symfony 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
                     -   php: "8.2"
                     -   php: "8.3"
                     -   php: "8.4"
+                    -   php: "8.4"
+                        symfony-version: 8.0.x-dev
+                        composer-stability: dev
         steps:
             -   name: Checkout source
                 uses: actions/checkout@v4
@@ -27,8 +30,18 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, log_errors_max_len=0
+            -   name: Install and configure Symfony Flex
+                if: matrix.symfony-version
+                run: |
+                    composer global require --no-progress --no-scripts --no-plugins symfony/flex
+                    composer global config --no-plugins allow-plugins.symfony/flex true
+            -   name: Configure Composer minimum-stability
+                if: matrix.composer-stability
+                run: composer config minimum-stability ${{ matrix.composer-stability }}
             -   name: "Update composer dependencies"
                 run: composer update -o --no-interaction --no-progress ${{ matrix.COMPOSER_FLAGS }}
+                env:
+                    SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
             -   name: Tests
                 env:
                     PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,7 @@ jobs:
                     -   php: "8.2"
                     -   php: "8.3"
                     -   php: "8.4"
-                    -   php: "8.4"
-                        symfony-version: 8.0.x-dev
-                        composer-stability: dev
+                        composer-stability: beta
         steps:
             -   name: Checkout source
                 uses: actions/checkout@v4
@@ -30,18 +28,11 @@ jobs:
                 with:
                     php-version: ${{ matrix.php }}
                     ini-values: zend.assertions=1, error_reporting=-1, display_errors=On, log_errors_max_len=0
-            -   name: Install and configure Symfony Flex
-                if: matrix.symfony-version
-                run: |
-                    composer global require --no-progress --no-scripts --no-plugins symfony/flex
-                    composer global config --no-plugins allow-plugins.symfony/flex true
             -   name: Configure Composer minimum-stability
                 if: matrix.composer-stability
                 run: composer config minimum-stability ${{ matrix.composer-stability }}
             -   name: "Update composer dependencies"
                 run: composer update -o --no-interaction --no-progress ${{ matrix.COMPOSER_FLAGS }}
-                env:
-                    SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
             -   name: Tests
                 env:
                     PHP_CS_FIXER_IGNORE_ENV: ${{ matrix.PHP_CS_FIXER_IGNORE_ENV }}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "symfony/process": "^5.4 || ^6.4 || ^7.2"
+        "symfony/process": "^5.4 || ^6.4 || ^7.2 || ^8.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.75",


### PR DESCRIPTION
This PR increase version constraints on `symfony/*` packages to allow Symfony 8, which will be released this month.
